### PR TITLE
feat: Web版にグループ分け機能を追加

### DIFF
--- a/packages/core/__tests__/grouping.test.ts
+++ b/packages/core/__tests__/grouping.test.ts
@@ -1,0 +1,98 @@
+import { divideIntoGroups, GROUPING_METHODS, isValidGroupingMethod } from "../src/grouping";
+import type { GroupingMethod } from "../src/grouping";
+
+describe("divideIntoGroups", () => {
+  // 決定論的テスト用: 0.1, 0.2, 0.3... を返すランダム関数
+  let callCount: number;
+  const deterministicRandom = () => {
+    callCount += 1;
+    return callCount * 0.1;
+  };
+
+  beforeEach(() => {
+    callCount = 0;
+  });
+
+  it("均等分割: 6人→3グループ = 2,2,2", () => {
+    const items = ["A", "B", "C", "D", "E", "F"];
+    const groups = divideIntoGroups(items, 3, "random", deterministicRandom);
+    expect(groups).toHaveLength(3);
+    expect(groups[0].items).toHaveLength(2);
+    expect(groups[1].items).toHaveLength(2);
+    expect(groups[2].items).toHaveLength(2);
+    // 全員が割り当てられている
+    const allItems = groups.flatMap((g) => g.items);
+    expect(allItems.sort()).toEqual(items.sort());
+  });
+
+  it("端数分割: 7人→3グループ = 3,2,2", () => {
+    const items = ["A", "B", "C", "D", "E", "F", "G"];
+    const groups = divideIntoGroups(items, 3, "random", deterministicRandom);
+    expect(groups).toHaveLength(3);
+    expect(groups[0].items).toHaveLength(3);
+    expect(groups[1].items).toHaveLength(2);
+    expect(groups[2].items).toHaveLength(2);
+    const allItems = groups.flatMap((g) => g.items);
+    expect(allItems.sort()).toEqual(items.sort());
+  });
+
+  it("各人が1グループ: 3人→3グループ = 1,1,1", () => {
+    const items = ["A", "B", "C"];
+    const groups = divideIntoGroups(items, 3, "random", deterministicRandom);
+    expect(groups).toHaveLength(3);
+    groups.forEach((g) => expect(g.items).toHaveLength(1));
+  });
+
+  it("2グループ: 5人→2グループ = 3,2", () => {
+    const items = ["A", "B", "C", "D", "E"];
+    const groups = divideIntoGroups(items, 2, "random", deterministicRandom);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].items).toHaveLength(3);
+    expect(groups[1].items).toHaveLength(2);
+  });
+
+  it("randomテーマはGroup N形式のラベルを返す", () => {
+    const items = ["A", "B", "C", "D"];
+    const groups = divideIntoGroups(items, 2, "random", deterministicRandom);
+    expect(groups[0].label).toBe("Group 1");
+    expect(groups[1].label).toBe("Group 2");
+  });
+
+  it.each(["zodiac", "element", "color"] as GroupingMethod[])(
+    "%s テーマはラベルと色を持つ",
+    (method) => {
+      const items = ["A", "B", "C", "D"];
+      const groups = divideIntoGroups(items, 2, method, deterministicRandom);
+      expect(groups).toHaveLength(2);
+      groups.forEach((g) => {
+        expect(g.label).toBeTruthy();
+        expect(g.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      });
+    },
+  );
+
+  it("groupCount < 2 でエラー", () => {
+    expect(() => divideIntoGroups(["A", "B"], 1)).toThrow(
+      "groupCount must be >= 2",
+    );
+  });
+
+  it("groupCount > items.length でエラー", () => {
+    expect(() => divideIntoGroups(["A", "B"], 3)).toThrow(
+      "groupCount must be <= items.length",
+    );
+  });
+});
+
+describe("isValidGroupingMethod", () => {
+  it("有効なメソッドを判定", () => {
+    for (const method of GROUPING_METHODS) {
+      expect(isValidGroupingMethod(method)).toBe(true);
+    }
+  });
+
+  it("無効なメソッドを拒否", () => {
+    expect(isValidGroupingMethod("invalid")).toBe(false);
+    expect(isValidGroupingMethod("")).toBe(false);
+  });
+});

--- a/packages/core/src/grouping.ts
+++ b/packages/core/src/grouping.ts
@@ -1,0 +1,168 @@
+import { cryptoRandom } from "./roulette";
+import { shuffleArray } from "./shuffle";
+
+/** グループ分け結果の1グループ */
+export interface GroupResult {
+  /** グループのラベル (e.g., "Group 1", "Aries ♈", "Fire 🔥") */
+  label: string;
+  /** 表示用のHexカラー */
+  color: string;
+  /** このグループに割り当てられたメンバー */
+  items: string[];
+}
+
+/** 利用可能なグループ分けテーマ */
+export type GroupingMethod = "random" | "zodiac" | "element" | "color";
+
+interface GroupMeta {
+  label: string;
+  color: string;
+}
+
+interface GroupingCriteria {
+  getGroupMeta(count: number): GroupMeta[];
+}
+
+const ZODIAC_SIGNS: GroupMeta[] = [
+  { label: "Aries ♈", color: "#FF6B6B" },
+  { label: "Taurus ♉", color: "#98FB98" },
+  { label: "Gemini ♊", color: "#FFD700" },
+  { label: "Cancer ♋", color: "#87CEEB" },
+  { label: "Leo ♌", color: "#FFA500" },
+  { label: "Virgo ♍", color: "#90EE90" },
+  { label: "Libra ♎", color: "#E6E6FA" },
+  { label: "Scorpio ♏", color: "#FF4D4D" },
+  { label: "Sagittarius ♐", color: "#DA70D6" },
+  { label: "Capricorn ♑", color: "#40E0D0" },
+  { label: "Aquarius ♒", color: "#4169E1" },
+  { label: "Pisces ♓", color: "#48D1CC" },
+];
+
+const ELEMENTS: GroupMeta[] = [
+  { label: "Fire 🔥", color: "#FF6B6B" },
+  { label: "Water 💧", color: "#4169E1" },
+  { label: "Earth 🌍", color: "#8B6914" },
+  { label: "Wind 🌪️", color: "#87CEEB" },
+  { label: "Lightning ⚡", color: "#FFD700" },
+  { label: "Ice ❄️", color: "#B0E0E6" },
+];
+
+const COLOR_TEAMS: GroupMeta[] = [
+  { label: "Red Team 🔴", color: "#FF6B6B" },
+  { label: "Blue Team 🔵", color: "#4169E1" },
+  { label: "Green Team 🟢", color: "#2E8B57" },
+  { label: "Yellow Team 🟡", color: "#DAA520" },
+  { label: "Purple Team 🟣", color: "#9370DB" },
+  { label: "Orange Team 🟠", color: "#FF8C00" },
+];
+
+const DEFAULT_GROUP_COLORS = [
+  "#FF6B6B",
+  "#4169E1",
+  "#2E8B57",
+  "#DAA520",
+  "#9370DB",
+  "#FF8C00",
+  "#40E0D0",
+  "#FF69B4",
+  "#87CEEB",
+  "#32CD32",
+  "#E6E6FA",
+  "#FF4D4D",
+];
+
+function createThemedCriteria(themes: GroupMeta[]): GroupingCriteria {
+  return {
+    getGroupMeta(count: number): GroupMeta[] {
+      const shuffled = shuffleArray(themes);
+      if (count <= themes.length) {
+        return shuffled.slice(0, count);
+      }
+      // テーマ数を超える場合はサイクルして番号を付与
+      const result: GroupMeta[] = [];
+      for (let i = 0; i < count; i++) {
+        const base = themes[i % themes.length];
+        result.push(
+          i < themes.length
+            ? shuffled[i]
+            : { label: `${base.label} (${Math.floor(i / themes.length) + 1})`, color: base.color }
+        );
+      }
+      return result;
+    },
+  };
+}
+
+const GROUPING_CRITERIA: Record<GroupingMethod, GroupingCriteria> = {
+  random: {
+    getGroupMeta(count: number): GroupMeta[] {
+      return Array.from({ length: count }, (_, i) => ({
+        label: `Group ${i + 1}`,
+        color: DEFAULT_GROUP_COLORS[i % DEFAULT_GROUP_COLORS.length],
+      }));
+    },
+  },
+  zodiac: createThemedCriteria(ZODIAC_SIGNS),
+  element: createThemedCriteria(ELEMENTS),
+  color: createThemedCriteria(COLOR_TEAMS),
+};
+
+/**
+ * アイテムをN個のグループにランダムに分ける。
+ *
+ * 各アイテムにランダムスコアを割り当て、ソートし、上から順にグループに分配する。
+ * 端数は先頭グループから順に1つずつ追加される（例: 7人→3グループ = 3,2,2）。
+ */
+export function divideIntoGroups(
+  items: string[],
+  groupCount: number,
+  method: GroupingMethod = "random",
+  random: () => number = cryptoRandom,
+): GroupResult[] {
+  if (groupCount < 2) throw new Error("groupCount must be >= 2");
+  if (groupCount > items.length)
+    throw new Error("groupCount must be <= items.length");
+
+  // ランダムスコアを割り当ててソート
+  const scored = items.map((item) => ({ item, score: random() }));
+  scored.sort((a, b) => a.score - b.score);
+
+  // グループメタデータ（ラベル、色）を取得
+  const criteria = GROUPING_CRITERIA[method];
+  const groupMeta = criteria.getGroupMeta(groupCount);
+
+  // グループ初期化
+  const groups: GroupResult[] = groupMeta.map((meta) => ({
+    ...meta,
+    items: [],
+  }));
+
+  // 上から順にグループに分配
+  const baseSize = Math.floor(items.length / groupCount);
+  const remainder = items.length % groupCount;
+  let idx = 0;
+  for (let g = 0; g < groupCount; g++) {
+    const size = baseSize + (g < remainder ? 1 : 0);
+    for (let j = 0; j < size; j++) {
+      groups[g].items.push(scored[idx].item);
+      idx++;
+    }
+  }
+
+  return groups;
+}
+
+/** 利用可能なグループ分けテーマの一覧 */
+export const GROUPING_METHODS: GroupingMethod[] = [
+  "random",
+  "zodiac",
+  "element",
+  "color",
+];
+
+/** 文字列がGroupingMethodかどうかを判定 */
+export function isValidGroupingMethod(
+  method: string,
+): method is GroupingMethod {
+  return (GROUPING_METHODS as string[]).includes(method);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,5 @@ export type { RouletteLogic } from "./roulette";
 export { shuffleArray } from "./shuffle";
 export { COLORS, getColorBrightness } from "./colors";
 export type { RouletteHistoryEntry, RouletteHistory } from "./types";
+export { divideIntoGroups, GROUPING_METHODS, isValidGroupingMethod } from "./grouping";
+export type { GroupResult, GroupingMethod } from "./grouping";

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { RouletteCanvas, RouletteCanvasRef } from "./components/RouletteCanvas";
 import { RouletteResult } from "./components/RouletteResult";
@@ -12,6 +12,11 @@ import { Footer } from "./components/Footer";
 import { RouletteHistory } from "./components/RouletteHistory";
 import { useRouletteHistory } from "./hooks/useRouletteHistory";
 import { LanguageSwitcher } from "./components/LanguageSwitcher";
+import { ModeSwitcher, type AppMode } from "./components/ModeSwitcher";
+import { GroupControls } from "./components/GroupControls";
+import { GroupAnimation } from "./components/GroupAnimation";
+import { GroupResultDisplay } from "./components/GroupResultDisplay";
+import { useGroupDivision } from "./hooks/useGroupDivision";
 
 // スタイルのインポート
 import "./styles/base.css";
@@ -20,13 +25,18 @@ import "./styles/components/RouletteCanvas.css";
 import "./styles/components/RouletteResult.css";
 import "./styles/components/RouletteActions.css";
 import "./styles/components/Snackbar.css";
-import "./styles/themes/dark.css";
-import "./styles/responsive.css";
 import "./styles/components/RouletteHistory.css";
 import "./styles/components/LanguageSwitcher.css";
+import "./styles/components/ModeSwitcher.css";
+import "./styles/components/GroupControls.css";
+import "./styles/components/GroupResult.css";
+// テーマ・レスポンシブは全コンポーネントCSSの後に読み込む
+import "./styles/themes/dark.css";
+import "./styles/responsive.css";
 
 function App() {
   const { t } = useTranslation();
+  const [mode, setMode] = useState<AppMode>("roulette");
   const canvasRef = useRef<RouletteCanvasRef>(null);
   const {
     optionsText,
@@ -47,62 +57,134 @@ function App() {
       quickMode,
     });
   const { isVisible, message, showSnackbar, hideSnackbar } = useSnackbar();
+  const {
+    groupCount,
+    setGroupCount,
+    groupingMethod,
+    setGroupingMethod,
+    groups,
+    isDividing,
+    animationStep,
+    animationItems,
+    totalAnimationSteps,
+    divide,
+    reset: resetGroups,
+  } = useGroupDivision({ options, quickMode });
 
   const handleShuffle = useCallback(() => {
     shuffleOptions();
   }, [shuffleOptions]);
 
+  const handleModeChange = useCallback(
+    (newMode: AppMode) => {
+      setMode(newMode);
+      resetGroups();
+    },
+    [resetGroups],
+  );
+
+  const isBusy = isSpinning || isDividing;
+
   return (
     <div className="container">
       <LanguageSwitcher />
-      <RouletteHistory history={history} onClear={clearHistory} />
+      {mode === "roulette" && (
+        <RouletteHistory history={history} onClear={clearHistory} />
+      )}
       <h1 className="main-title">🎯 Lucky Roulette</h1>
+
+      <ModeSwitcher mode={mode} onChange={handleModeChange} disabled={isBusy} />
 
       <RouletteInput
         optionsText={optionsText}
         onChange={handleOptionsChange}
         onShuffle={handleShuffle}
-        canShuffle={options.length > 1 && !isSpinning}
-        disabled={isSpinning}
+        canShuffle={options.length > 1 && !isBusy}
+        disabled={isBusy}
         shuffleCount={shuffleCount}
         onShuffleCountChange={handleShuffleCountChange}
       />
 
-      <div className="roulette-section">
-        <div className="canvas-container">
-          <RouletteCanvas
-            ref={canvasRef}
-            options={displayOptions}
-            rotation={rotation}
-          />
-          <RouletteActions
-            canvasElement={canvasRef.current?.getCanvas() || null}
-            currentOption={currentOption}
-            isVisible={!!currentOption && !isSpinning}
-            onSuccess={showSnackbar}
-          />
-        </div>
-        <RouletteResult isSpinning={isSpinning} currentOption={currentOption} />
-        <div className="spin-controls">
-          <button
-            onClick={spin}
-            disabled={!hasOptions || isSpinning}
-            className="spin-button"
-          >
-            {t("app.spin")}
-          </button>
-          <label className="quick-mode-label">
-            <input
-              type="checkbox"
-              checked={quickMode}
-              onChange={handleQuickModeChange}
-              disabled={isSpinning}
-              className="quick-mode-checkbox"
+      {mode === "roulette" && (
+        <div className="roulette-section">
+          <div className="canvas-container">
+            <RouletteCanvas
+              ref={canvasRef}
+              options={displayOptions}
+              rotation={rotation}
             />
-            {t("app.quickMode")}
-          </label>
+            <RouletteActions
+              canvasElement={canvasRef.current?.getCanvas() || null}
+              currentOption={currentOption}
+              isVisible={!!currentOption && !isSpinning}
+              onSuccess={showSnackbar}
+            />
+          </div>
+          <RouletteResult isSpinning={isSpinning} currentOption={currentOption} />
+          <div className="spin-controls">
+            <button
+              onClick={spin}
+              disabled={!hasOptions || isSpinning}
+              className="spin-button"
+            >
+              {t("app.spin")}
+            </button>
+            <label className="quick-mode-label">
+              <input
+                type="checkbox"
+                checked={quickMode}
+                onChange={handleQuickModeChange}
+                disabled={isSpinning}
+                className="quick-mode-checkbox"
+              />
+              {t("app.quickMode")}
+            </label>
+          </div>
         </div>
-      </div>
+      )}
+
+      {mode === "grouping" && (
+        <div className="grouping-section">
+          <GroupControls
+            groupCount={groupCount}
+            onGroupCountChange={setGroupCount}
+            groupingMethod={groupingMethod}
+            onGroupingMethodChange={setGroupingMethod}
+            maxGroups={Math.max(2, options.length)}
+            disabled={isDividing}
+          />
+
+          <div className="spin-controls">
+            <button
+              onClick={divide}
+              disabled={options.length < 2 || isDividing || groupCount > options.length}
+              className="divide-button"
+            >
+              {t("grouping.divide")}
+            </button>
+            <label className="quick-mode-label">
+              <input
+                type="checkbox"
+                checked={quickMode}
+                onChange={handleQuickModeChange}
+                disabled={isDividing}
+                className="quick-mode-checkbox"
+              />
+              {t("app.quickMode")}
+            </label>
+          </div>
+
+          {isDividing && (
+            <GroupAnimation
+              items={animationItems}
+              step={animationStep}
+              totalSteps={totalAnimationSteps}
+            />
+          )}
+
+          {groups && !isDividing && <GroupResultDisplay groups={groups} />}
+        </div>
+      )}
 
       <Footer />
       <Snackbar

--- a/packages/web/src/components/GroupAnimation.tsx
+++ b/packages/web/src/components/GroupAnimation.tsx
@@ -1,0 +1,50 @@
+import { type FC } from "react";
+import { useTranslation } from "react-i18next";
+import { COLORS, getColorBrightness } from "@tainakanchu/roulette-core";
+
+interface GroupAnimationProps {
+  items: string[];
+  step: number;
+  totalSteps: number;
+}
+
+export const GroupAnimation: FC<GroupAnimationProps> = ({
+  items,
+  step,
+  totalSteps,
+}) => {
+  const { t } = useTranslation();
+  const progress = Math.min(step / totalSteps, 1);
+
+  return (
+    <div className="group-animation">
+      <div className="group-animation-header">
+        <span className="group-animation-label">
+          {t("grouping.dividing")}
+        </span>
+        <div className="group-animation-progress">
+          <div
+            className="group-animation-progress-bar"
+            style={{ width: `${progress * 100}%` }}
+          />
+        </div>
+      </div>
+      <div className="group-animation-items">
+        {items.map((item, i) => {
+          const color = COLORS[i % COLORS.length];
+          const textColor =
+            getColorBrightness(color) > 128 ? "#000000" : "#FFFFFF";
+          return (
+            <span
+              key={i}
+              className="group-animation-item"
+              style={{ backgroundColor: color, color: textColor }}
+            >
+              {item}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/web/src/components/GroupControls.tsx
+++ b/packages/web/src/components/GroupControls.tsx
@@ -1,0 +1,72 @@
+import { type ChangeEvent, type FC } from "react";
+import { useTranslation } from "react-i18next";
+import { GROUPING_METHODS, type GroupingMethod } from "@tainakanchu/roulette-core";
+
+interface GroupControlsProps {
+  groupCount: number;
+  onGroupCountChange: (count: number) => void;
+  groupingMethod: GroupingMethod;
+  onGroupingMethodChange: (method: GroupingMethod) => void;
+  maxGroups: number;
+  disabled?: boolean;
+}
+
+export const GroupControls: FC<GroupControlsProps> = ({
+  groupCount,
+  onGroupCountChange,
+  groupingMethod,
+  onGroupingMethodChange,
+  maxGroups,
+  disabled = false,
+}) => {
+  const { t } = useTranslation();
+
+  const handleCountChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number.parseInt(e.target.value, 10);
+    if (!Number.isNaN(value) && value >= 2 && value <= maxGroups) {
+      onGroupCountChange(value);
+    }
+  };
+
+  const handleMethodChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    onGroupingMethodChange(e.target.value as GroupingMethod);
+  };
+
+  return (
+    <div className="group-controls">
+      <div className="group-control-row">
+        <label htmlFor="group-count" className="group-control-label">
+          {t("grouping.groupCount")}
+        </label>
+        <input
+          id="group-count"
+          type="number"
+          min={2}
+          max={maxGroups}
+          value={groupCount}
+          onChange={handleCountChange}
+          disabled={disabled}
+          className="group-count-input"
+        />
+      </div>
+      <div className="group-control-row">
+        <label htmlFor="group-theme" className="group-control-label">
+          {t("grouping.theme")}
+        </label>
+        <select
+          id="group-theme"
+          value={groupingMethod}
+          onChange={handleMethodChange}
+          disabled={disabled}
+          className="group-theme-select"
+        >
+          {GROUPING_METHODS.map((method) => (
+            <option key={method} value={method}>
+              {t(`grouping.themes.${method}`)}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};

--- a/packages/web/src/components/GroupResultDisplay.tsx
+++ b/packages/web/src/components/GroupResultDisplay.tsx
@@ -1,0 +1,43 @@
+import { type FC } from "react";
+import { useTranslation } from "react-i18next";
+import { getColorBrightness, type GroupResult } from "@tainakanchu/roulette-core";
+
+interface GroupResultDisplayProps {
+  groups: GroupResult[];
+}
+
+export const GroupResultDisplay: FC<GroupResultDisplayProps> = ({ groups }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="group-result">
+      <h3 className="group-result-title">{t("grouping.resultTitle")}</h3>
+      <div className="group-result-grid">
+        {groups.map((group, index) => {
+          const textColor =
+            getColorBrightness(group.color) > 128 ? "#000000" : "#FFFFFF";
+          return (
+            <div key={index} className="group-card">
+              <div
+                className="group-card-header"
+                style={{ backgroundColor: group.color, color: textColor }}
+              >
+                <span className="group-card-label">{group.label}</span>
+                <span className="group-card-count">
+                  {t("grouping.members", { count: group.items.length })}
+                </span>
+              </div>
+              <ul className="group-card-members">
+                {group.items.map((item, i) => (
+                  <li key={i} className="group-card-member">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/web/src/components/ModeSwitcher.tsx
+++ b/packages/web/src/components/ModeSwitcher.tsx
@@ -1,0 +1,39 @@
+import { type FC } from "react";
+import { useTranslation } from "react-i18next";
+
+export type AppMode = "roulette" | "grouping";
+
+interface ModeSwitcherProps {
+  mode: AppMode;
+  onChange: (mode: AppMode) => void;
+  disabled?: boolean;
+}
+
+export const ModeSwitcher: FC<ModeSwitcherProps> = ({
+  mode,
+  onChange,
+  disabled = false,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mode-switcher">
+      <button
+        type="button"
+        className={`mode-switcher-tab ${mode === "roulette" ? "active" : ""}`}
+        onClick={() => onChange("roulette")}
+        disabled={disabled}
+      >
+        🎯 {t("mode.roulette")}
+      </button>
+      <button
+        type="button"
+        className={`mode-switcher-tab ${mode === "grouping" ? "active" : ""}`}
+        onClick={() => onChange("grouping")}
+        disabled={disabled}
+      >
+        👥 {t("mode.grouping")}
+      </button>
+    </div>
+  );
+};

--- a/packages/web/src/hooks/useGroupDivision.ts
+++ b/packages/web/src/hooks/useGroupDivision.ts
@@ -1,0 +1,90 @@
+import { useState, useCallback, useRef } from "react";
+import {
+  divideIntoGroups,
+  shuffleArray,
+  type GroupResult,
+  type GroupingMethod,
+} from "@tainakanchu/roulette-core";
+import { useShakeSound } from "./useShakeSound";
+
+interface UseGroupDivisionProps {
+  options: string[];
+  quickMode?: boolean;
+}
+
+export const useGroupDivision = ({
+  options,
+  quickMode = false,
+}: UseGroupDivisionProps) => {
+  const [groupCount, setGroupCount] = useState(2);
+  const [groupingMethod, setGroupingMethod] = useState<GroupingMethod>("random");
+  const [groups, setGroups] = useState<GroupResult[] | null>(null);
+  const [isDividing, setIsDividing] = useState(false);
+  const [animationStep, setAnimationStep] = useState(0);
+  const [animationItems, setAnimationItems] = useState<string[]>([]);
+  const animationRef = useRef<ReturnType<typeof setTimeout>>();
+  const shakeSound = useShakeSound();
+
+  const totalAnimationSteps = quickMode ? 8 : 20;
+
+  const divide = useCallback(() => {
+    if (options.length < 2 || groupCount < 2 || groupCount > options.length) {
+      return;
+    }
+
+    setIsDividing(true);
+    setGroups(null);
+    setAnimationStep(0);
+    setAnimationItems(options);
+
+    // 最終結果を先に計算
+    const finalGroups = divideIntoGroups(options, groupCount, groupingMethod);
+
+    // シャッフルアニメーション
+    shakeSound.start();
+    let step = 0;
+
+    const animate = () => {
+      step += 1;
+      setAnimationStep(step);
+      setAnimationItems((prev) => shuffleArray(prev));
+
+      if (step < totalAnimationSteps) {
+        // 徐々にゆっくりに
+        const delay = quickMode ? 30 + step * 5 : 50 + step * 15;
+        animationRef.current = setTimeout(animate, delay);
+      } else {
+        // アニメーション完了 → 結果表示
+        shakeSound.stop();
+        setIsDividing(false);
+        setGroups(finalGroups);
+      }
+    };
+
+    animationRef.current = setTimeout(animate, 50);
+  }, [options, groupCount, groupingMethod, quickMode, shakeSound, totalAnimationSteps]);
+
+  const reset = useCallback(() => {
+    if (animationRef.current) {
+      clearTimeout(animationRef.current);
+    }
+    shakeSound.stop();
+    setGroups(null);
+    setIsDividing(false);
+    setAnimationStep(0);
+  }, [shakeSound]);
+
+  return {
+    groupCount,
+    setGroupCount,
+    groupingMethod,
+    setGroupingMethod,
+    groups,
+    isDividing,
+    animationStep,
+    animationItems,
+    totalAnimationSteps,
+    divide,
+    reset,
+  };
+};

--- a/packages/web/src/i18n/locales/en/translation.json
+++ b/packages/web/src/i18n/locales/en/translation.json
@@ -25,6 +25,24 @@
     "copyTitle": "Copy result image to clipboard",
     "downloadTitle": "Download result image"
   },
+  "mode": {
+    "roulette": "Roulette",
+    "grouping": "Group Division"
+  },
+  "grouping": {
+    "groupCount": "Groups:",
+    "theme": "Theme:",
+    "themes": {
+      "random": "Simple",
+      "zodiac": "Zodiac",
+      "element": "Element",
+      "color": "Color Team"
+    },
+    "divide": "Divide into Groups",
+    "dividing": "Dividing...",
+    "resultTitle": "Group Division Result",
+    "members": "{{count}} members"
+  },
   "history": {
     "toggle": "History",
     "title": "Win History",

--- a/packages/web/src/i18n/locales/id/translation.json
+++ b/packages/web/src/i18n/locales/id/translation.json
@@ -25,6 +25,24 @@
     "copyTitle": "Salin gambar hasil ke clipboard",
     "downloadTitle": "Unduh gambar hasil"
   },
+  "mode": {
+    "roulette": "Roulette",
+    "grouping": "Pembagian Grup"
+  },
+  "grouping": {
+    "groupCount": "Jumlah grup:",
+    "theme": "Tema:",
+    "themes": {
+      "random": "Sederhana",
+      "zodiac": "Zodiak",
+      "element": "Elemen",
+      "color": "Tim Warna"
+    },
+    "divide": "Bagi ke Grup",
+    "dividing": "Membagi...",
+    "resultTitle": "Hasil Pembagian Grup",
+    "members": "{{count}} anggota"
+  },
   "history": {
     "toggle": "Riwayat",
     "title": "Riwayat Kemenangan",

--- a/packages/web/src/i18n/locales/ja/translation.json
+++ b/packages/web/src/i18n/locales/ja/translation.json
@@ -25,6 +25,24 @@
     "copyTitle": "結果画像をクリップボードにコピー",
     "downloadTitle": "結果画像をダウンロード"
   },
+  "mode": {
+    "roulette": "ルーレット",
+    "grouping": "グループ分け"
+  },
+  "grouping": {
+    "groupCount": "グループ数:",
+    "theme": "テーマ:",
+    "themes": {
+      "random": "シンプル",
+      "zodiac": "星座",
+      "element": "属性",
+      "color": "カラーチーム"
+    },
+    "divide": "グループ分けする",
+    "dividing": "グループ分け中...",
+    "resultTitle": "グループ分け結果",
+    "members": "{{count}}人"
+  },
   "history": {
     "toggle": "履歴",
     "title": "当選履歴",

--- a/packages/web/src/i18n/locales/zh-HK/translation.json
+++ b/packages/web/src/i18n/locales/zh-HK/translation.json
@@ -25,6 +25,24 @@
     "copyTitle": "複製結果圖片到剪貼簿",
     "downloadTitle": "下載結果圖片"
   },
+  "mode": {
+    "roulette": "輪盤",
+    "grouping": "分組"
+  },
+  "grouping": {
+    "groupCount": "組數:",
+    "theme": "主題:",
+    "themes": {
+      "random": "簡單",
+      "zodiac": "星座",
+      "element": "屬性",
+      "color": "顏色隊伍"
+    },
+    "divide": "開始分組",
+    "dividing": "分組中...",
+    "resultTitle": "分組結果",
+    "members": "{{count}}人"
+  },
   "history": {
     "toggle": "歷史",
     "title": "中獎歷史",

--- a/packages/web/src/i18n/locales/zh-TW/translation.json
+++ b/packages/web/src/i18n/locales/zh-TW/translation.json
@@ -25,6 +25,24 @@
     "copyTitle": "複製結果圖片到剪貼簿",
     "downloadTitle": "下載結果圖片"
   },
+  "mode": {
+    "roulette": "輪盤",
+    "grouping": "分組"
+  },
+  "grouping": {
+    "groupCount": "組數:",
+    "theme": "主題:",
+    "themes": {
+      "random": "簡單",
+      "zodiac": "星座",
+      "element": "屬性",
+      "color": "顏色隊伍"
+    },
+    "divide": "開始分組",
+    "dividing": "分組中...",
+    "resultTitle": "分組結果",
+    "members": "{{count}}人"
+  },
   "history": {
     "toggle": "歷史",
     "title": "中獎歷史",

--- a/packages/web/src/styles/components/GroupControls.css
+++ b/packages/web/src/styles/components/GroupControls.css
@@ -1,0 +1,60 @@
+.group-controls {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.group-control-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.group-control-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #555;
+  white-space: nowrap;
+}
+
+.group-count-input {
+  width: 64px;
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  text-align: center;
+}
+
+.group-count-input:focus {
+  outline: none;
+  border-color: #4CAF50;
+  box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.2);
+}
+
+.group-count-input:disabled {
+  background: #f5f5f5;
+  color: #999;
+}
+
+.group-theme-select {
+  padding: 6px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  background: white;
+  cursor: pointer;
+}
+
+.group-theme-select:focus {
+  outline: none;
+  border-color: #4CAF50;
+  box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.2);
+}
+
+.group-theme-select:disabled {
+  background: #f5f5f5;
+  color: #999;
+  cursor: not-allowed;
+}

--- a/packages/web/src/styles/components/GroupResult.css
+++ b/packages/web/src/styles/components/GroupResult.css
@@ -1,0 +1,162 @@
+.group-result {
+  margin-top: 1.5rem;
+  animation: fadeIn 0.4s ease;
+}
+
+.group-result-title {
+  font-size: 1.2rem;
+  color: #2c3e50;
+  margin: 0 0 1rem;
+  text-align: center;
+}
+
+.group-result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.group-card {
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  animation: slideUp 0.3s ease backwards;
+}
+
+.group-card:nth-child(1) { animation-delay: 0.05s; }
+.group-card:nth-child(2) { animation-delay: 0.1s; }
+.group-card:nth-child(3) { animation-delay: 0.15s; }
+.group-card:nth-child(4) { animation-delay: 0.2s; }
+.group-card:nth-child(5) { animation-delay: 0.25s; }
+.group-card:nth-child(6) { animation-delay: 0.3s; }
+
+.group-card-header {
+  padding: 10px 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.group-card-label {
+  font-weight: 700;
+  font-size: 15px;
+}
+
+.group-card-count {
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.group-card-members {
+  list-style: none;
+  margin: 0;
+  padding: 8px 14px;
+  background: white;
+}
+
+.group-card-member {
+  padding: 5px 0;
+  font-size: 14px;
+  color: #333;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.group-card-member:last-child {
+  border-bottom: none;
+}
+
+/* Animation */
+.group-animation {
+  margin-top: 1.5rem;
+}
+
+.group-animation-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.group-animation-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #666;
+  white-space: nowrap;
+}
+
+.group-animation-progress {
+  flex: 1;
+  height: 6px;
+  background: #e0e0e0;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.group-animation-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #4CAF50, #2196f3);
+  border-radius: 3px;
+  transition: width 0.1s ease;
+}
+
+.group-animation-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+}
+
+.group-animation-item {
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 500;
+  transition: transform 0.05s ease;
+  animation: itemBounce 0.15s ease;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(15px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes itemBounce {
+  0% { transform: scale(0.9); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+/* Divide button */
+.divide-button {
+  width: 100%;
+  padding: 14px;
+  font-size: 18px;
+  font-weight: 700;
+  color: white;
+  background: linear-gradient(135deg, #9370DB, #4169E1);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-top: 0.5rem;
+}
+
+.divide-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(65, 105, 225, 0.4);
+}
+
+.divide-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.divide-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/packages/web/src/styles/components/ModeSwitcher.css
+++ b/packages/web/src/styles/components/ModeSwitcher.css
@@ -1,0 +1,34 @@
+.mode-switcher {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1.5rem;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 2px solid #e0e0e0;
+}
+
+.mode-switcher-tab {
+  flex: 1;
+  padding: 10px 16px;
+  border: none;
+  background: #f5f5f5;
+  color: #666;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mode-switcher-tab:hover:not(:disabled) {
+  background: #e8e8e8;
+}
+
+.mode-switcher-tab.active {
+  background: #4CAF50;
+  color: white;
+}
+
+.mode-switcher-tab:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/packages/web/src/styles/responsive.css
+++ b/packages/web/src/styles/responsive.css
@@ -63,4 +63,24 @@
     font-size: 12px;
     margin-top: 4px;
   }
+
+  /* Group Controls */
+  .group-controls {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .group-result-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .divide-button {
+    font-size: 16px;
+    padding: 10px;
+  }
+
+  .mode-switcher-tab {
+    font-size: 13px;
+    padding: 8px 12px;
+  }
 } 

--- a/packages/web/src/styles/themes/dark.css
+++ b/packages/web/src/styles/themes/dark.css
@@ -75,4 +75,83 @@
   .quick-mode-label {
     color: #dcdcdc;
   }
+
+  /* Mode Switcher */
+  .mode-switcher {
+    border-color: #444;
+  }
+
+  .mode-switcher-tab {
+    background: #2a2a2a;
+    color: #aaa;
+  }
+
+  .mode-switcher-tab:hover:not(:disabled) {
+    background: #333;
+  }
+
+  .mode-switcher-tab.active {
+    background: #4CAF50;
+    color: white;
+  }
+
+  /* Group Controls */
+  .group-control-label {
+    color: #dcdcdc;
+  }
+
+  .group-count-input {
+    background: #2a2a2a;
+    border-color: #444;
+    color: #ffffff;
+  }
+
+  .group-count-input:disabled {
+    background: #1a1a1a;
+    color: #666;
+  }
+
+  .group-theme-select {
+    background: #2a2a2a;
+    border-color: #444;
+    color: #ffffff;
+    color-scheme: dark;
+  }
+
+  .group-theme-select option {
+    background: #2a2a2a;
+    color: #ffffff;
+  }
+
+  .group-theme-select:disabled {
+    background: #1a1a1a;
+    color: #666;
+  }
+
+  /* Group Result */
+  .group-result-title {
+    color: #ffffff;
+  }
+
+  .group-card {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  .group-card-members {
+    background: #2a2a2a;
+  }
+
+  .group-card-member {
+    color: #dcdcdc;
+    border-bottom-color: #3a3a3a;
+  }
+
+  /* Group Animation */
+  .group-animation-label {
+    color: #aaa;
+  }
+
+  .group-animation-progress {
+    background: #333;
+  }
 } 


### PR DESCRIPTION
## Summary
- 選択肢をランダムにN個のグループに振り分ける「グループ分け」モードを追加
- 4種のテーマ（シンプル/星座/属性/カラーチーム）でグループ名を付与可能
- シャッフルアニメーション付き、ダークモード・レスポンシブ・5言語対応

## Changes
- **Core**: `packages/core/src/grouping.ts` にグループ分けロジック追加（ランダムスコア→ソート→分配）
- **Web**: モード切替タブ（ルーレット/グループ分け）、設定UI、アニメーション、結果カード表示
- **i18n**: ja/en/zh-TW/zh-HK/id の5言語に翻訳追加
- **CSS**: ダークモードでのセレクトボックス表示修正（CSSインポート順整理）

## Test plan
- [x] Core unit tests (12テスト全パス: 均等・端数分割、テーマ、エラーケース)
- [x] ダークモードでテーマセレクトが正しく表示される
- [x] グループ分け結果がカード形式で表示される
- [x] ルーレットモードに戻しても既存機能が正常動作
- [ ] 各言語での表示確認
- [ ] モバイルレスポンシブ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)