### PR TITLE
feat: Web版にバトルモード（多数決抽選）機能を追加

### DIFF
--- a/packages/core/__tests__/battle.test.ts
+++ b/packages/core/__tests__/battle.test.ts
@@ -1,0 +1,47 @@
+import { drawBattleSequence, tallyBattle } from "../src/battle";
+
+describe("battle", () => {
+  describe("drawBattleSequence", () => {
+    it("指定された回数分の index を返す", () => {
+      const sequence = drawBattleSequence(4, 100);
+      expect(sequence).toHaveLength(100);
+      sequence.forEach((idx) => {
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(idx).toBeLessThan(4);
+        expect(Number.isInteger(idx)).toBe(true);
+      });
+    });
+
+    it("optionCount が 0 なら空配列", () => {
+      expect(drawBattleSequence(0, 10)).toEqual([]);
+    });
+
+    it("drawCount が 0 なら空配列", () => {
+      expect(drawBattleSequence(5, 0)).toEqual([]);
+    });
+
+    it("random を差し替えると決定的な結果を返す", () => {
+      let call = 0;
+      const values = [0.0, 0.25, 0.5, 0.75, 0.999];
+      const mockRandom = () => values[call++ % values.length];
+      const sequence = drawBattleSequence(4, 5, mockRandom);
+      expect(sequence).toEqual([0, 1, 2, 3, 3]);
+    });
+  });
+
+  describe("tallyBattle", () => {
+    it("各 index の出現回数を集計する", () => {
+      const counts = tallyBattle(4, [0, 1, 1, 2, 2, 2, 3, 3, 3, 3]);
+      expect(counts).toEqual([1, 2, 3, 4]);
+    });
+
+    it("範囲外の index は無視する", () => {
+      const counts = tallyBattle(3, [0, 1, 2, 3, -1, 10]);
+      expect(counts).toEqual([1, 1, 1]);
+    });
+
+    it("draws が空なら全てゼロ", () => {
+      expect(tallyBattle(3, [])).toEqual([0, 0, 0]);
+    });
+  });
+});

--- a/packages/core/src/battle.ts
+++ b/packages/core/src/battle.ts
@@ -1,0 +1,27 @@
+import { cryptoRandom } from "./roulette";
+
+export const drawBattleSequence = (
+  optionCount: number,
+  drawCount: number,
+  random: () => number = cryptoRandom
+): number[] => {
+  if (optionCount <= 0 || drawCount <= 0) return [];
+  const sequence: number[] = new Array(drawCount);
+  for (let i = 0; i < drawCount; i += 1) {
+    sequence[i] = Math.floor(random() * optionCount);
+  }
+  return sequence;
+};
+
+export const tallyBattle = (
+  optionCount: number,
+  draws: number[]
+): number[] => {
+  const counts = new Array<number>(optionCount).fill(0);
+  for (const idx of draws) {
+    if (idx >= 0 && idx < optionCount) {
+      counts[idx] += 1;
+    }
+  }
+  return counts;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export { COLORS, getColorBrightness } from "./colors";
 export type { RouletteHistoryEntry, RouletteHistory } from "./types";
 export { divideIntoGroups, GROUPING_METHODS, isValidGroupingMethod } from "./grouping";
 export type { GroupResult, GroupingMethod } from "./grouping";
+export { drawBattleSequence, tallyBattle } from "./battle";

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,9 +1,10 @@
-import { useState, useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RouletteCanvas, RouletteCanvasRef } from "./components/RouletteCanvas";
 import { RouletteResult } from "./components/RouletteResult";
 import { RouletteInput } from "./components/RouletteInput";
 import { RouletteActions } from "./components/RouletteActions";
+import { BattleMode } from "./components/BattleMode";
 import { useRouletteOptions } from "./hooks/useRouletteOptions";
 import { useRouletteAnimation } from "./hooks/useRouletteAnimation";
 import { useSnackbar } from "./hooks/useSnackbar";
@@ -17,6 +18,7 @@ import { GroupControls } from "./components/GroupControls";
 import { GroupAnimation } from "./components/GroupAnimation";
 import { GroupResultDisplay } from "./components/GroupResultDisplay";
 import { useGroupDivision } from "./hooks/useGroupDivision";
+import { readLocalStorage, writeLocalStorage } from "./utils/localStorage";
 
 // スタイルのインポート
 import "./styles/base.css";
@@ -30,14 +32,28 @@ import "./styles/components/LanguageSwitcher.css";
 import "./styles/components/ModeSwitcher.css";
 import "./styles/components/GroupControls.css";
 import "./styles/components/GroupResult.css";
+import "./styles/components/BattleMode.css";
 // テーマ・レスポンシブは全コンポーネントCSSの後に読み込む
 import "./styles/themes/dark.css";
 import "./styles/responsive.css";
 
+const MODE_STORAGE_KEY = "roulette-mode";
+
+const readInitialMode = (): AppMode => {
+  const stored = readLocalStorage(MODE_STORAGE_KEY);
+  if (stored === "grouping" || stored === "battle") return stored;
+  return "roulette";
+};
+
 function App() {
   const { t } = useTranslation();
-  const [mode, setMode] = useState<AppMode>("roulette");
+  const [mode, setMode] = useState<AppMode>(readInitialMode);
   const canvasRef = useRef<RouletteCanvasRef>(null);
+
+  useEffect(() => {
+    writeLocalStorage(MODE_STORAGE_KEY, mode);
+  }, [mode]);
+
   const {
     optionsText,
     options,
@@ -184,6 +200,10 @@ function App() {
 
           {groups && !isDividing && <GroupResultDisplay groups={groups} />}
         </div>
+      )}
+
+      {mode === "battle" && (
+        <BattleMode options={options} onFinish={addHistoryEntry} />
       )}
 
       <Footer />

--- a/packages/web/src/components/BattleBars.tsx
+++ b/packages/web/src/components/BattleBars.tsx
@@ -1,0 +1,64 @@
+import { type FC, useMemo } from "react";
+import { COLORS } from "@tainakanchu/roulette-core";
+
+const ROW_HEIGHT_PX = 40;
+
+interface BattleBarsProps {
+  options: string[];
+  counts: number[];
+  winner: string | null;
+}
+
+export const BattleBars: FC<BattleBarsProps> = ({ options, counts, winner }) => {
+  const maxCount = Math.max(1, ...counts);
+
+  const rankByIndex = useMemo(() => {
+    const entries = options.map((_, i) => ({
+      index: i,
+      count: counts[i] ?? 0,
+    }));
+    entries.sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.index - b.index;
+    });
+    const map = new Map<number, number>();
+    entries.forEach((entry, rank) => map.set(entry.index, rank));
+    return map;
+  }, [options, counts]);
+
+  return (
+    <div
+      className="battle-bars"
+      style={{ height: `${options.length * ROW_HEIGHT_PX}px` }}
+    >
+      {options.map((option, index) => {
+        const count = counts[index] ?? 0;
+        const widthPct = (count / maxCount) * 100;
+        const color = COLORS[index % COLORS.length];
+        const isWinner = winner !== null && option === winner;
+        const rank = rankByIndex.get(index) ?? 0;
+        return (
+          <div
+            key={`${index}-${option}`}
+            className={`battle-bar-row ${isWinner ? "is-winner" : ""}`}
+            style={{ transform: `translateY(${rank * ROW_HEIGHT_PX}px)` }}
+          >
+            <div className="battle-bar-label" title={option}>
+              {option}
+            </div>
+            <div className="battle-bar-track">
+              <div
+                className="battle-bar-fill"
+                style={{
+                  width: `${widthPct}%`,
+                  backgroundColor: color,
+                }}
+              />
+              <span className="battle-bar-count">{count}</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/web/src/components/BattleControls.tsx
+++ b/packages/web/src/components/BattleControls.tsx
@@ -1,0 +1,68 @@
+import { type ChangeEvent, type FC } from "react";
+import { useTranslation } from "react-i18next";
+
+interface BattleControlsProps {
+  drawCount: number;
+  onDrawCountChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onStart: () => void;
+  onReset: () => void;
+  isRunning: boolean;
+  canStart: boolean;
+  processedCount: number;
+  hasResult: boolean;
+}
+
+export const BattleControls: FC<BattleControlsProps> = ({
+  drawCount,
+  onDrawCountChange,
+  onStart,
+  onReset,
+  isRunning,
+  canStart,
+  processedCount,
+  hasResult,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="battle-controls">
+      <div className="battle-draw-count">
+        <label htmlFor="battle-draw-count" className="battle-draw-count-label">
+          {t("battle.drawCount")}
+        </label>
+        <input
+          id="battle-draw-count"
+          type="number"
+          min="1"
+          max="100000"
+          step="1"
+          value={drawCount}
+          onChange={onDrawCountChange}
+          disabled={isRunning}
+          className="battle-draw-count-input"
+        />
+      </div>
+      <div className="battle-actions">
+        <button
+          type="button"
+          onClick={onStart}
+          disabled={!canStart || isRunning}
+          className="battle-start-button"
+        >
+          {t("battle.start")}
+        </button>
+        <button
+          type="button"
+          onClick={onReset}
+          disabled={isRunning || (!hasResult && processedCount === 0)}
+          className="battle-reset-button"
+        >
+          {t("battle.reset")}
+        </button>
+      </div>
+      <div className="battle-progress">
+        {t("battle.progress", { current: processedCount, total: drawCount })}
+      </div>
+    </div>
+  );
+};

--- a/packages/web/src/components/BattleMode.tsx
+++ b/packages/web/src/components/BattleMode.tsx
@@ -1,0 +1,88 @@
+import { type ChangeEvent, type FC, useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { readLocalStorage, writeLocalStorage } from "../utils/localStorage";
+import { useBattleMode } from "../hooks/useBattleMode";
+import { BattleBars } from "./BattleBars";
+import { BattleControls } from "./BattleControls";
+
+const DRAW_COUNT_STORAGE_KEY = "roulette-battle-draw-count";
+const DEFAULT_DRAW_COUNT = 1000;
+
+interface BattleModeProps {
+  options: string[];
+  onFinish?: (winner: string) => void;
+}
+
+export const BattleMode: FC<BattleModeProps> = ({ options, onFinish }) => {
+  const { t } = useTranslation();
+
+  const [drawCount, setDrawCount] = useState(() => {
+    const stored = readLocalStorage(DRAW_COUNT_STORAGE_KEY);
+    const parsed = stored ? Number.parseInt(stored, 10) : NaN;
+    if (!Number.isNaN(parsed) && parsed >= 1) return parsed;
+    return DEFAULT_DRAW_COUNT;
+  });
+
+  useEffect(() => {
+    writeLocalStorage(DRAW_COUNT_STORAGE_KEY, drawCount.toString());
+  }, [drawCount]);
+
+  const handleDrawCountChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const value = Number.parseInt(e.target.value, 10);
+    if (!Number.isNaN(value) && value >= 1) {
+      setDrawCount(value);
+    }
+  }, []);
+
+  const {
+    counts,
+    processedCount,
+    suddenDeathCount,
+    isRunning,
+    isSuddenDeath,
+    result,
+    start,
+    reset,
+  } = useBattleMode({
+    options,
+    drawCount,
+    onFinish,
+  });
+
+  const canStart = options.length >= 2 && drawCount >= 1;
+  const winner = result?.winner ?? null;
+
+  return (
+    <div className="battle-mode">
+      <BattleControls
+        drawCount={drawCount}
+        onDrawCountChange={handleDrawCountChange}
+        onStart={start}
+        onReset={reset}
+        isRunning={isRunning}
+        canStart={canStart}
+        processedCount={processedCount}
+        hasResult={result !== null}
+      />
+
+      {isSuddenDeath && (
+        <div className="battle-sudden-death">
+          ⚡ {t("battle.suddenDeath", { count: suddenDeathCount })}
+        </div>
+      )}
+
+      {options.length === 0 ? (
+        <p className="battle-empty">{t("battle.empty")}</p>
+      ) : (
+        <BattleBars options={options} counts={counts} winner={winner} />
+      )}
+
+      {result && (
+        <div className="battle-winner">
+          <div className="battle-winner-label">{t("battle.winner")}</div>
+          <div className="battle-winner-value">{result.winner}</div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/components/ModeSwitcher.tsx
+++ b/packages/web/src/components/ModeSwitcher.tsx
@@ -1,7 +1,7 @@
 import { type FC } from "react";
 import { useTranslation } from "react-i18next";
 
-export type AppMode = "roulette" | "grouping";
+export type AppMode = "roulette" | "grouping" | "battle";
 
 interface ModeSwitcherProps {
   mode: AppMode;
@@ -33,6 +33,14 @@ export const ModeSwitcher: FC<ModeSwitcherProps> = ({
         disabled={disabled}
       >
         👥 {t("mode.grouping")}
+      </button>
+      <button
+        type="button"
+        className={`mode-switcher-tab ${mode === "battle" ? "active" : ""}`}
+        onClick={() => onChange("battle")}
+        disabled={disabled}
+      >
+        ⚔️ {t("mode.battle")}
       </button>
     </div>
   );

--- a/packages/web/src/hooks/useBattleMode.ts
+++ b/packages/web/src/hooks/useBattleMode.ts
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cryptoRandom, drawBattleSequence } from "@tainakanchu/roulette-core";
+
+const MS_PER_DRAW = 5;
+const MAX_DURATION_MS = 5000;
+const UI_UPDATE_INTERVAL_MS = 33;
+const SUDDEN_DEATH_FIRST_DELAY_MS = 500;
+const SUDDEN_DEATH_INTERVAL_MS = 280;
+
+const calcDuration = (drawCount: number): number => {
+  if (drawCount <= 0) return 0;
+  return Math.min(MAX_DURATION_MS, drawCount * MS_PER_DRAW);
+};
+
+interface UseBattleModeProps {
+  options: string[];
+  drawCount: number;
+  onFinish?: (winner: string) => void;
+}
+
+export interface BattleResult {
+  winner: string;
+  counts: number[];
+}
+
+export const useBattleMode = ({
+  options,
+  drawCount,
+  onFinish,
+}: UseBattleModeProps) => {
+  const [counts, setCounts] = useState<number[]>(() =>
+    new Array(options.length).fill(0)
+  );
+  const [processedCount, setProcessedCount] = useState(0);
+  const [suddenDeathCount, setSuddenDeathCount] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isSuddenDeath, setIsSuddenDeath] = useState(false);
+  const [result, setResult] = useState<BattleResult | null>(null);
+  const cancelRef = useRef<(() => void) | null>(null);
+
+  const optionsKey = useMemo(() => options.join(",|,"), [options]);
+
+  useEffect(() => {
+    setCounts(new Array(options.length).fill(0));
+    setProcessedCount(0);
+    setSuddenDeathCount(0);
+    setResult(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [optionsKey]);
+
+  const cancel = useCallback(() => {
+    if (cancelRef.current !== null) {
+      cancelRef.current();
+      cancelRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => cancel(), [cancel]);
+
+  const reset = useCallback(() => {
+    cancel();
+    setIsRunning(false);
+    setIsSuddenDeath(false);
+    setCounts(new Array(options.length).fill(0));
+    setProcessedCount(0);
+    setSuddenDeathCount(0);
+    setResult(null);
+  }, [cancel, options.length]);
+
+  const start = useCallback(() => {
+    if (isRunning) return;
+    if (options.length === 0 || drawCount <= 0) return;
+
+    const sequence = drawBattleSequence(options.length, drawCount);
+    const duration = calcDuration(drawCount);
+    const startTime = performance.now();
+    const initialCounts = new Array(options.length).fill(0);
+    setCounts(initialCounts);
+    setProcessedCount(0);
+    setSuddenDeathCount(0);
+    setResult(null);
+    setIsSuddenDeath(false);
+    setIsRunning(true);
+
+    const localCounts = [...initialCounts];
+    let lastProcessed = 0;
+    let lastUiUpdate = 0;
+
+    const finishWith = (winnerIdx: number) => {
+      setResult({
+        winner: options[winnerIdx] ?? "",
+        counts: [...localCounts],
+      });
+      setIsRunning(false);
+      setIsSuddenDeath(false);
+      cancelRef.current = null;
+      onFinish?.(options[winnerIdx] ?? "");
+    };
+
+    const findUniqueTop = (): number | null => {
+      let maxVal = -Infinity;
+      let topIdx = 0;
+      let tieCount = 0;
+      for (let i = 0; i < localCounts.length; i += 1) {
+        if (localCounts[i] > maxVal) {
+          maxVal = localCounts[i];
+          topIdx = i;
+          tieCount = 1;
+        } else if (localCounts[i] === maxVal) {
+          tieCount += 1;
+        }
+      }
+      return tieCount === 1 ? topIdx : null;
+    };
+
+    const runSuddenDeath = () => {
+      setIsSuddenDeath(true);
+      let sdCount = 0;
+
+      const tick = () => {
+        const pick = Math.floor(cryptoRandom() * options.length);
+        localCounts[pick] += 1;
+        sdCount += 1;
+        setCounts([...localCounts]);
+        setSuddenDeathCount(sdCount);
+
+        const uniqueTop = findUniqueTop();
+        if (uniqueTop !== null) {
+          finishWith(uniqueTop);
+          return;
+        }
+
+        const timeoutId = window.setTimeout(tick, SUDDEN_DEATH_INTERVAL_MS);
+        cancelRef.current = () => window.clearTimeout(timeoutId);
+      };
+
+      const timeoutId = window.setTimeout(tick, SUDDEN_DEATH_FIRST_DELAY_MS);
+      cancelRef.current = () => window.clearTimeout(timeoutId);
+    };
+
+    const step = (now: number) => {
+      const elapsed = now - startTime;
+      const progress = duration === 0 ? 1 : Math.min(elapsed / duration, 1);
+      const target = Math.floor(progress * sequence.length);
+
+      if (target > lastProcessed) {
+        for (let i = lastProcessed; i < target; i += 1) {
+          localCounts[sequence[i]] += 1;
+        }
+        lastProcessed = target;
+        if (now - lastUiUpdate >= UI_UPDATE_INTERVAL_MS) {
+          setCounts(localCounts.slice());
+          setProcessedCount(target);
+          lastUiUpdate = now;
+        }
+      }
+
+      if (progress < 1) {
+        const rafId = requestAnimationFrame(step);
+        cancelRef.current = () => cancelAnimationFrame(rafId);
+        return;
+      }
+
+      for (let i = lastProcessed; i < sequence.length; i += 1) {
+        localCounts[sequence[i]] += 1;
+      }
+      setCounts([...localCounts]);
+      setProcessedCount(sequence.length);
+
+      const uniqueTop = findUniqueTop();
+      if (uniqueTop !== null) {
+        finishWith(uniqueTop);
+        return;
+      }
+
+      runSuddenDeath();
+    };
+
+    const rafId = requestAnimationFrame(step);
+    cancelRef.current = () => cancelAnimationFrame(rafId);
+  }, [isRunning, options, drawCount, onFinish]);
+
+  return {
+    counts,
+    processedCount,
+    suddenDeathCount,
+    isRunning,
+    isSuddenDeath,
+    result,
+    start,
+    reset,
+  };
+};

--- a/packages/web/src/i18n/locales/en/translation.json
+++ b/packages/web/src/i18n/locales/en/translation.json
@@ -27,7 +27,8 @@
   },
   "mode": {
     "roulette": "Roulette",
-    "grouping": "Group Division"
+    "grouping": "Group Division",
+    "battle": "Battle"
   },
   "grouping": {
     "groupCount": "Groups:",
@@ -42,6 +43,15 @@
     "dividing": "Dividing...",
     "resultTitle": "Group Division Result",
     "members": "{{count}} members"
+  },
+  "battle": {
+    "drawCount": "Draws:",
+    "start": "Start",
+    "reset": "Reset",
+    "progress": "{{current}} / {{total}}",
+    "winner": "🏆 Winner",
+    "empty": "Please enter your options",
+    "suddenDeath": "Sudden death! Redrawing until someone pulls ahead (+{{count}})"
   },
   "history": {
     "toggle": "History",

--- a/packages/web/src/i18n/locales/id/translation.json
+++ b/packages/web/src/i18n/locales/id/translation.json
@@ -27,7 +27,8 @@
   },
   "mode": {
     "roulette": "Roulette",
-    "grouping": "Pembagian Grup"
+    "grouping": "Pembagian Grup",
+    "battle": "Pertarungan"
   },
   "grouping": {
     "groupCount": "Jumlah grup:",
@@ -42,6 +43,15 @@
     "dividing": "Membagi...",
     "resultTitle": "Hasil Pembagian Grup",
     "members": "{{count}} anggota"
+  },
+  "battle": {
+    "drawCount": "Jumlah undian:",
+    "start": "Mulai",
+    "reset": "Atur ulang",
+    "progress": "{{current}} / {{total}}",
+    "winner": "🏆 Pemenang",
+    "empty": "Masukkan pilihan Anda",
+    "suddenDeath": "Sudden death! Mengundi ulang hingga ada pemenang (+{{count}})"
   },
   "history": {
     "toggle": "Riwayat",

--- a/packages/web/src/i18n/locales/ja/translation.json
+++ b/packages/web/src/i18n/locales/ja/translation.json
@@ -27,7 +27,8 @@
   },
   "mode": {
     "roulette": "ルーレット",
-    "grouping": "グループ分け"
+    "grouping": "グループ分け",
+    "battle": "バトル"
   },
   "grouping": {
     "groupCount": "グループ数:",
@@ -42,6 +43,15 @@
     "dividing": "グループ分け中...",
     "resultTitle": "グループ分け結果",
     "members": "{{count}}人"
+  },
+  "battle": {
+    "drawCount": "抽選回数:",
+    "start": "スタート",
+    "reset": "リセット",
+    "progress": "{{current}} / {{total}}",
+    "winner": "🏆 勝者",
+    "empty": "選択肢を入力してください",
+    "suddenDeath": "サドンデス！差が出るまで再抽選中… (+{{count}})"
   },
   "history": {
     "toggle": "履歴",

--- a/packages/web/src/i18n/locales/zh-HK/translation.json
+++ b/packages/web/src/i18n/locales/zh-HK/translation.json
@@ -27,7 +27,8 @@
   },
   "mode": {
     "roulette": "輪盤",
-    "grouping": "分組"
+    "grouping": "分組",
+    "battle": "對戰"
   },
   "grouping": {
     "groupCount": "組數:",
@@ -42,6 +43,15 @@
     "dividing": "分組中...",
     "resultTitle": "分組結果",
     "members": "{{count}}人"
+  },
+  "battle": {
+    "drawCount": "抽籤次數:",
+    "start": "開始",
+    "reset": "重置",
+    "progress": "{{current}} / {{total}}",
+    "winner": "🏆 勝者",
+    "empty": "請輸入選項",
+    "suddenDeath": "突然死！重新抽籤直到分出勝負 (+{{count}})"
   },
   "history": {
     "toggle": "歷史",

--- a/packages/web/src/i18n/locales/zh-TW/translation.json
+++ b/packages/web/src/i18n/locales/zh-TW/translation.json
@@ -27,7 +27,8 @@
   },
   "mode": {
     "roulette": "輪盤",
-    "grouping": "分組"
+    "grouping": "分組",
+    "battle": "對戰"
   },
   "grouping": {
     "groupCount": "組數:",
@@ -42,6 +43,15 @@
     "dividing": "分組中...",
     "resultTitle": "分組結果",
     "members": "{{count}}人"
+  },
+  "battle": {
+    "drawCount": "抽籤次數:",
+    "start": "開始",
+    "reset": "重置",
+    "progress": "{{current}} / {{total}}",
+    "winner": "🏆 勝者",
+    "empty": "請輸入選項",
+    "suddenDeath": "驟死賽！重新抽籤直到分出勝負 (+{{count}})"
   },
   "history": {
     "toggle": "歷史",

--- a/packages/web/src/styles/components/BattleMode.css
+++ b/packages/web/src/styles/components/BattleMode.css
@@ -1,0 +1,213 @@
+.battle-mode {
+  margin-top: 16px;
+}
+
+.battle-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  align-items: center;
+  padding: 12px;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+
+.battle-draw-count {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.battle-draw-count-label {
+  font-size: 14px;
+  color: #333;
+}
+
+.battle-draw-count-input {
+  width: 90px;
+  padding: 6px 8px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.battle-draw-count-input:disabled {
+  background-color: #f5f5f5;
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.battle-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.battle-start-button,
+.battle-reset-button {
+  padding: 8px 18px;
+  font-size: 14px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s, opacity 0.2s;
+  color: #fff;
+}
+
+.battle-start-button {
+  background-color: #4caf50;
+}
+
+.battle-start-button:hover:not(:disabled) {
+  background-color: #388e3c;
+}
+
+.battle-reset-button {
+  background-color: #9e9e9e;
+}
+
+.battle-reset-button:hover:not(:disabled) {
+  background-color: #757575;
+}
+
+.battle-start-button:disabled,
+.battle-reset-button:disabled {
+  background-color: #b0bec5;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.battle-progress {
+  margin-left: auto;
+  font-size: 13px;
+  color: #555;
+  font-variant-numeric: tabular-nums;
+}
+
+.battle-bars {
+  position: relative;
+  padding: 0;
+  max-height: 480px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.battle-bar-row {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 32px;
+  display: grid;
+  grid-template-columns: minmax(80px, 25%) 1fr;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter 240ms ease;
+  will-change: transform;
+  contain: layout paint;
+}
+
+.battle-bar-row.is-winner {
+  filter: drop-shadow(0 0 8px rgba(255, 152, 0, 0.45));
+  z-index: 1;
+}
+
+.battle-bar-label {
+  font-size: 14px;
+  color: #333;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.battle-bar-row.is-winner .battle-bar-label {
+  color: #c62828;
+  font-weight: 700;
+}
+
+.battle-bar-track {
+  position: relative;
+  height: 28px;
+  background-color: #eceff1;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.battle-bar-fill {
+  height: 100%;
+  border-radius: 14px;
+}
+
+.battle-bar-count {
+  position: absolute;
+  top: 0;
+  right: 10px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: #263238;
+  font-variant-numeric: tabular-nums;
+}
+
+.battle-winner {
+  margin-top: 20px;
+  padding: 16px;
+  background: linear-gradient(135deg, #fff8e1, #ffe0b2);
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(255, 152, 0, 0.2);
+  animation: fadeIn 0.4s ease-out;
+}
+
+.battle-winner-label {
+  font-size: 14px;
+  color: #e65100;
+  letter-spacing: 0.1em;
+}
+
+.battle-winner-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #bf360c;
+  margin-top: 4px;
+  word-break: break-word;
+}
+
+.battle-empty {
+  padding: 24px;
+  text-align: center;
+  color: #888;
+  font-size: 14px;
+  background-color: #fafafa;
+  border-radius: 8px;
+}
+
+.battle-sudden-death {
+  margin: 12px 0;
+  padding: 10px 16px;
+  background: linear-gradient(90deg, #ff5252, #ff1744);
+  color: #fff;
+  border-radius: 8px;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.08em;
+  animation: suddenDeathPulse 0.9s ease-in-out infinite alternate;
+}
+
+@keyframes suddenDeathPulse {
+  from {
+    box-shadow: 0 0 0 rgba(255, 23, 68, 0.4);
+    transform: scale(1);
+  }
+  to {
+    box-shadow: 0 0 18px rgba(255, 23, 68, 0.8);
+    transform: scale(1.02);
+  }
+}


### PR DESCRIPTION
## 概要

ルーレット・グループ分けに続く 3 つ目のモードとして **バトルモード** を追加。
選択肢ごとに指定回数の抽選を行い、当選回数を棒グラフでニョキニョキ伸ばしていく多数決式ルーレット。

## 主な仕様

- 票数降順で **都度ソート**（`transform: translateY` + cubic-bezier でぬるっと並び替え）
- 規定回数後に同票の場合は **差が出るまで全員対象のサドンデス再抽選**
- 抽選速度は **ms/draw 比例**（小回数は素早く、大回数は最大 5 秒にキャップ）
- UI 更新を **33ms スロットリング**して 1000 回抽選時の描画負荷を軽減
- 選択肢 0 / 1 件の場合はスタート不可

## UI

- `ModeSwitcher` を 🎯 ルーレット / 👥 グループ分け / ⚔️ バトル の 3 モードに拡張
- 抽選回数は `localStorage` に保存（デフォルト 1000）
- サドンデス中は ⚡ バナーでパルス演出
- 確定時は🏆 勝者を大きく表示

## 実装

- `packages/core/src/battle.ts`
  - `drawBattleSequence(optionCount, drawCount, random?)` — 抽選 index 配列
  - `tallyBattle(optionCount, draws)` — 集計
  - 単体テスト `packages/core/__tests__/battle.test.ts`
- `packages/web/src/hooks/useBattleMode.ts` — アニメーション制御、サドンデス
- `packages/web/src/components/BattleMode.tsx` / `BattleBars.tsx` / `BattleControls.tsx`
- `packages/web/src/styles/components/BattleMode.css`
- 5 言語（ja / en / id / zh-HK / zh-TW）の i18n に翻訳キー追加

## 確認済み

- `pnpm -r type-check` 全通過
- `pnpm lint` 通過
- `pnpm -r test` 全通過（battle 6 件 + roulette-logic 6 件）
- ブラウザでの 3 モード切替・バトル抽選・サドンデス動作確認