### PR TITLE
feat(web): ダークモード対応・モードURLクエリ保存・結果画像DL機能

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# プロジェクト作業ルール
+
+このリポジトリで作業する際のガイドライン。
+
+## Web UI を追加・変更するときはダークモード対応も同時に行う
+
+`packages/web` に新しいコンポーネント・CSS を追加したり既存の CSS クラスを新設したら、必ず `packages/web/src/styles/themes/dark.css` の `@media (prefers-color-scheme: dark)` ブロック内に対応する上書きを追加すること。
+
+- 背景色（`#fff`, `#f5f5f5`, `#f8f9fa`, `#eceff1` 等）、前景色（`#000`, `#333` 等）、ボーダー色など、ライト前提の色を書いたら必ず dark 側の上書きを用意する
+- 既存コンポーネント（RouletteInput / ModeSwitcher / GroupControls 等）はすべて dark.css に個別エントリがあり、同じスタイルに合わせる
+- 作業完了前にブラウザで `prefers-color-scheme: dark` の見た目を確認する（DevTools → Rendering → Emulate CSS media feature）
+
+## モノレポ構成
+
+- `packages/core` — 抽選・グループ分けなどのドメインロジック（React 非依存）
+- `packages/web` — React + Vite の Web アプリ
+- `packages/cli` — React Ink の CLI
+
+共通の型・関数は core に置き、web/cli から `@tainakanchu/roulette-core` として import する。
+
+## i18n
+
+翻訳キーは 5 言語すべて（ja / en / id / zh-HK / zh-TW）に同じ構造で追加する。
+ファイル: `packages/web/src/i18n/locales/<lang>/translation.json`
+
+## 動作確認
+
+UI 変更は以下を済ませてから完了とする。
+
+1. `pnpm -r type-check`
+2. `pnpm lint`
+3. `pnpm -r test`
+4. `pnpm dev` でブラウザ起動し、ライト / ダーク両方で見た目と挙動を確認

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -17,6 +17,7 @@ import { ModeSwitcher, type AppMode } from "./components/ModeSwitcher";
 import { GroupControls } from "./components/GroupControls";
 import { GroupAnimation } from "./components/GroupAnimation";
 import { GroupResultDisplay } from "./components/GroupResultDisplay";
+import { GroupActions } from "./components/GroupActions";
 import { useGroupDivision } from "./hooks/useGroupDivision";
 import { readLocalStorage, writeLocalStorage } from "./utils/localStorage";
 
@@ -38,11 +39,24 @@ import "./styles/themes/dark.css";
 import "./styles/responsive.css";
 
 const MODE_STORAGE_KEY = "roulette-mode";
+const MODE_QUERY_KEY = "mode";
+
+const isAppMode = (value: string | null): value is AppMode =>
+  value === "roulette" || value === "grouping" || value === "battle";
 
 const readInitialMode = (): AppMode => {
+  const params = new URLSearchParams(window.location.search);
+  const fromQuery = params.get(MODE_QUERY_KEY);
+  if (isAppMode(fromQuery)) return fromQuery;
   const stored = readLocalStorage(MODE_STORAGE_KEY);
-  if (stored === "grouping" || stored === "battle") return stored;
+  if (isAppMode(stored)) return stored;
   return "roulette";
+};
+
+const writeModeToURL = (mode: AppMode) => {
+  const url = new URL(window.location.href);
+  url.searchParams.set(MODE_QUERY_KEY, mode);
+  window.history.replaceState({}, "", url.toString());
 };
 
 function App() {
@@ -52,6 +66,7 @@ function App() {
 
   useEffect(() => {
     writeLocalStorage(MODE_STORAGE_KEY, mode);
+    writeModeToURL(mode);
   }, [mode]);
 
   const {
@@ -198,12 +213,21 @@ function App() {
             />
           )}
 
-          {groups && !isDividing && <GroupResultDisplay groups={groups} />}
+          {groups && !isDividing && (
+            <GroupResultDisplay
+              groups={groups}
+              actions={<GroupActions groups={groups} onSuccess={showSnackbar} />}
+            />
+          )}
         </div>
       )}
 
       {mode === "battle" && (
-        <BattleMode options={options} onFinish={addHistoryEntry} />
+        <BattleMode
+          options={options}
+          onFinish={addHistoryEntry}
+          onSuccess={showSnackbar}
+        />
       )}
 
       <Footer />

--- a/packages/web/src/components/BattleActions.tsx
+++ b/packages/web/src/components/BattleActions.tsx
@@ -1,0 +1,108 @@
+import { useState, type FC } from "react";
+import { useTranslation } from "react-i18next";
+import { COLORS } from "@tainakanchu/roulette-core";
+import {
+  generateBattleResultImage,
+  copyImageToClipboard,
+  downloadImage,
+} from "../utils/imageUtils";
+
+interface BattleActionsProps {
+  options: string[];
+  counts: number[];
+  winner: string;
+  onSuccess: (message: string) => void;
+}
+
+const buildFilename = (): string => {
+  const now = new Date();
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `battle-result-${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(
+    now.getDate()
+  )}-${pad(now.getHours())}${pad(now.getMinutes())}.png`;
+};
+
+export const BattleActions: FC<BattleActionsProps> = ({
+  options,
+  counts,
+  winner,
+  onSuccess,
+}) => {
+  const { t, i18n } = useTranslation();
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const generate = async (): Promise<Blob> => {
+    const entries = options
+      .map((label, index) => ({
+        label,
+        count: counts[index] ?? 0,
+        color: COLORS[index % COLORS.length],
+      }))
+      .sort((a, b) => b.count - a.count);
+    return generateBattleResultImage(
+      entries,
+      winner,
+      "🎯 Lucky Roulette",
+      t("battle.winner"),
+      i18n.language
+    );
+  };
+
+  const handleCopy = async () => {
+    if (!winner) return;
+    setIsGenerating(true);
+    try {
+      const blob = await generate();
+      await copyImageToClipboard(blob);
+      onSuccess(t("actions.copySuccess"));
+    } catch (error) {
+      console.error("Error copying battle result:", error);
+      onSuccess(t("actions.copyError"));
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleDownload = async () => {
+    if (!winner) return;
+    setIsGenerating(true);
+    try {
+      const blob = await generate();
+      downloadImage(blob, buildFilename());
+      onSuccess(t("actions.downloadSuccess"));
+    } catch (error) {
+      console.error("Error downloading battle result:", error);
+      onSuccess(t("actions.downloadError"));
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <div className="result-actions-inline">
+      <button
+        type="button"
+        onClick={handleCopy}
+        disabled={isGenerating}
+        className="action-button"
+        title={t("actions.copyTitle")}
+      >
+        📋
+      </button>
+      <button
+        type="button"
+        onClick={handleDownload}
+        disabled={isGenerating}
+        className="action-button"
+        title={t("actions.downloadTitle")}
+      >
+        💾
+      </button>
+      {isGenerating && (
+        <div className="generating-indicator">
+          <div className="spinner"></div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/components/BattleMode.tsx
+++ b/packages/web/src/components/BattleMode.tsx
@@ -4,6 +4,7 @@ import { readLocalStorage, writeLocalStorage } from "../utils/localStorage";
 import { useBattleMode } from "../hooks/useBattleMode";
 import { BattleBars } from "./BattleBars";
 import { BattleControls } from "./BattleControls";
+import { BattleActions } from "./BattleActions";
 
 const DRAW_COUNT_STORAGE_KEY = "roulette-battle-draw-count";
 const DEFAULT_DRAW_COUNT = 1000;
@@ -11,9 +12,10 @@ const DEFAULT_DRAW_COUNT = 1000;
 interface BattleModeProps {
   options: string[];
   onFinish?: (winner: string) => void;
+  onSuccess?: (message: string) => void;
 }
 
-export const BattleMode: FC<BattleModeProps> = ({ options, onFinish }) => {
+export const BattleMode: FC<BattleModeProps> = ({ options, onFinish, onSuccess }) => {
   const { t } = useTranslation();
 
   const [drawCount, setDrawCount] = useState(() => {
@@ -79,6 +81,14 @@ export const BattleMode: FC<BattleModeProps> = ({ options, onFinish }) => {
 
       {result && (
         <div className="battle-winner">
+          {onSuccess && (
+            <BattleActions
+              options={options}
+              counts={result.counts}
+              winner={result.winner}
+              onSuccess={onSuccess}
+            />
+          )}
           <div className="battle-winner-label">{t("battle.winner")}</div>
           <div className="battle-winner-value">{result.winner}</div>
         </div>

--- a/packages/web/src/components/GroupActions.tsx
+++ b/packages/web/src/components/GroupActions.tsx
@@ -1,0 +1,93 @@
+import { useState, type FC } from "react";
+import { useTranslation } from "react-i18next";
+import type { GroupResult } from "@tainakanchu/roulette-core";
+import {
+  generateGroupResultImage,
+  copyImageToClipboard,
+  downloadImage,
+} from "../utils/imageUtils";
+
+interface GroupActionsProps {
+  groups: GroupResult[];
+  onSuccess: (message: string) => void;
+}
+
+const buildFilename = (): string => {
+  const now = new Date();
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `grouping-result-${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(
+    now.getDate()
+  )}-${pad(now.getHours())}${pad(now.getMinutes())}.png`;
+};
+
+export const GroupActions: FC<GroupActionsProps> = ({ groups, onSuccess }) => {
+  const { t, i18n } = useTranslation();
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const generate = async (): Promise<Blob> => {
+    return generateGroupResultImage(
+      groups,
+      "🎯 Lucky Roulette",
+      t("grouping.resultTitle"),
+      i18n.language
+    );
+  };
+
+  const handleCopy = async () => {
+    if (groups.length === 0) return;
+    setIsGenerating(true);
+    try {
+      const blob = await generate();
+      await copyImageToClipboard(blob);
+      onSuccess(t("actions.copySuccess"));
+    } catch (error) {
+      console.error("Error copying group result:", error);
+      onSuccess(t("actions.copyError"));
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleDownload = async () => {
+    if (groups.length === 0) return;
+    setIsGenerating(true);
+    try {
+      const blob = await generate();
+      downloadImage(blob, buildFilename());
+      onSuccess(t("actions.downloadSuccess"));
+    } catch (error) {
+      console.error("Error downloading group result:", error);
+      onSuccess(t("actions.downloadError"));
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <div className="result-actions-inline">
+      <button
+        type="button"
+        onClick={handleCopy}
+        disabled={isGenerating}
+        className="action-button"
+        title={t("actions.copyTitle")}
+      >
+        📋
+      </button>
+      <button
+        type="button"
+        onClick={handleDownload}
+        disabled={isGenerating}
+        className="action-button"
+        title={t("actions.downloadTitle")}
+      >
+        💾
+      </button>
+      {isGenerating && (
+        <div className="generating-indicator">
+          <div className="spinner"></div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/components/GroupResultDisplay.tsx
+++ b/packages/web/src/components/GroupResultDisplay.tsx
@@ -1,16 +1,18 @@
-import { type FC } from "react";
+import { type FC, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { getColorBrightness, type GroupResult } from "@tainakanchu/roulette-core";
 
 interface GroupResultDisplayProps {
   groups: GroupResult[];
+  actions?: ReactNode;
 }
 
-export const GroupResultDisplay: FC<GroupResultDisplayProps> = ({ groups }) => {
+export const GroupResultDisplay: FC<GroupResultDisplayProps> = ({ groups, actions }) => {
   const { t } = useTranslation();
 
   return (
     <div className="group-result">
+      {actions}
       <h3 className="group-result-title">{t("grouping.resultTitle")}</h3>
       <div className="group-result-grid">
         {groups.map((group, index) => {

--- a/packages/web/src/styles/components/BattleMode.css
+++ b/packages/web/src/styles/components/BattleMode.css
@@ -157,6 +157,7 @@
 }
 
 .battle-winner {
+  position: relative;
   margin-top: 20px;
   padding: 16px;
   background: linear-gradient(135deg, #fff8e1, #ffe0b2);
@@ -164,6 +165,14 @@
   text-align: center;
   box-shadow: 0 2px 8px rgba(255, 152, 0, 0.2);
   animation: fadeIn 0.4s ease-out;
+}
+
+.result-actions-inline {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  gap: 6px;
 }
 
 .battle-winner-label {

--- a/packages/web/src/styles/components/GroupResult.css
+++ b/packages/web/src/styles/components/GroupResult.css
@@ -1,4 +1,5 @@
 .group-result {
+  position: relative;
   margin-top: 1.5rem;
   animation: fadeIn 0.4s ease;
 }

--- a/packages/web/src/styles/themes/dark.css
+++ b/packages/web/src/styles/themes/dark.css
@@ -154,4 +154,65 @@
   .group-animation-progress {
     background: #333;
   }
-} 
+
+  /* Battle Mode */
+  .battle-controls {
+    background-color: #222;
+  }
+
+  .battle-draw-count-label {
+    color: #dcdcdc;
+  }
+
+  .battle-draw-count-input {
+    background-color: #2a2a2a;
+    border-color: #444;
+    color: #ffffff;
+    color-scheme: dark;
+  }
+
+  .battle-draw-count-input:disabled {
+    background-color: #1a1a1a;
+    color: #666;
+  }
+
+  .battle-progress {
+    color: #aaa;
+  }
+
+  .battle-bar-label {
+    color: #dcdcdc;
+  }
+
+  .battle-bar-row.is-winner .battle-bar-label {
+    color: #ff8a80;
+  }
+
+  .battle-bar-track {
+    background-color: #2a2a2a;
+  }
+
+  .battle-bar-count {
+    color: #f5f5f5;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  }
+
+  .battle-empty {
+    background-color: #222;
+    color: #aaa;
+  }
+
+  .battle-winner {
+    background: linear-gradient(135deg, #3a2a10 0%, #4a2f14 100%);
+    box-shadow: 0 2px 8px rgba(255, 152, 0, 0.25);
+  }
+
+  .battle-winner-label {
+    color: #ffb74d;
+  }
+
+  .battle-winner-value {
+    color: #ffcc80;
+  }
+}
+

--- a/packages/web/src/utils/imageUtils.ts
+++ b/packages/web/src/utils/imageUtils.ts
@@ -83,6 +83,227 @@ export const generateRouletteResultImage = async (
   });
 };
 
+interface BattleImageEntry {
+  label: string;
+  count: number;
+  color: string;
+}
+
+export const generateBattleResultImage = async (
+  entries: BattleImageEntry[],
+  winner: string,
+  titleText: string,
+  winnerLabel: string,
+  language: string
+): Promise<Blob> => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas context not available");
+
+  const width = 720;
+  const padding = 40;
+  const titleHeight = 80;
+  const winnerBoxHeight = 120;
+  const rowHeight = 52;
+  const rowGap = 8;
+  const footerHeight = 50;
+  const maxVisibleRows = Math.min(entries.length, 12);
+  const barsHeight = maxVisibleRows * rowHeight + (maxVisibleRows - 1) * rowGap;
+  const height =
+    padding + titleHeight + winnerBoxHeight + 32 + barsHeight + footerHeight + padding;
+
+  canvas.width = width;
+  canvas.height = height;
+
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = "#333333";
+  ctx.font = "bold 30px sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText(titleText, width / 2, padding + 36);
+
+  const winnerBoxY = padding + titleHeight;
+  ctx.fillStyle = "#fff3e0";
+  ctx.strokeStyle = "#ffb74d";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.roundRect(padding, winnerBoxY, width - padding * 2, winnerBoxHeight, 12);
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.fillStyle = "#e65100";
+  ctx.font = "bold 18px sans-serif";
+  ctx.fillText(winnerLabel, width / 2, winnerBoxY + 36);
+
+  ctx.fillStyle = "#bf360c";
+  ctx.font = "bold 36px sans-serif";
+  ctx.fillText(winner, width / 2, winnerBoxY + 84);
+
+  const barsStartY = winnerBoxY + winnerBoxHeight + 32;
+  const barAreaX = padding + 160;
+  const barAreaWidth = width - padding - barAreaX - 8;
+  const maxCount = Math.max(1, ...entries.map((e) => e.count));
+  const visible = entries.slice(0, maxVisibleRows);
+
+  visible.forEach((entry, i) => {
+    const rowY = barsStartY + i * (rowHeight + rowGap);
+
+    ctx.fillStyle = "#263238";
+    ctx.font = "600 18px sans-serif";
+    ctx.textAlign = "right";
+    ctx.fillText(entry.label, padding + 150, rowY + rowHeight / 2 + 6);
+
+    ctx.fillStyle = "#eceff1";
+    ctx.beginPath();
+    ctx.roundRect(barAreaX, rowY + 6, barAreaWidth, rowHeight - 12, 12);
+    ctx.fill();
+
+    const fillWidth = Math.max(4, (entry.count / maxCount) * barAreaWidth);
+    ctx.fillStyle = entry.color;
+    ctx.beginPath();
+    ctx.roundRect(barAreaX, rowY + 6, fillWidth, rowHeight - 12, 12);
+    ctx.fill();
+
+    ctx.fillStyle = "#263238";
+    ctx.font = "bold 16px sans-serif";
+    ctx.textAlign = "right";
+    ctx.fillText(
+      entry.count.toString(),
+      barAreaX + barAreaWidth - 12,
+      rowY + rowHeight / 2 + 6
+    );
+  });
+
+  const now = new Date();
+  const dateString = now.toLocaleString(language);
+  ctx.fillStyle = "#6c757d";
+  ctx.font = "14px sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText(dateString, width / 2, height - padding + 10);
+
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else throw new Error("Failed to generate image blob");
+    }, "image/png");
+  });
+};
+
+interface GroupImageGroup {
+  label: string;
+  color: string;
+  items: string[];
+}
+
+export const generateGroupResultImage = async (
+  groups: GroupImageGroup[],
+  titleText: string,
+  resultLabel: string,
+  language: string
+): Promise<Blob> => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas context not available");
+
+  const padding = 40;
+  const columnGap = 20;
+  const columns = groups.length <= 2 ? groups.length : groups.length <= 4 ? 2 : 3;
+  const columnWidth = 260;
+  const cardPadding = 16;
+  const cardHeaderHeight = 48;
+  const itemHeight = 28;
+  const width = padding * 2 + columns * columnWidth + (columns - 1) * columnGap;
+  const titleHeight = 80;
+
+  const rows = Math.ceil(groups.length / columns);
+  let maxItemsPerRow = 0;
+  for (let r = 0; r < rows; r += 1) {
+    for (let c = 0; c < columns; c += 1) {
+      const idx = r * columns + c;
+      if (idx >= groups.length) break;
+      maxItemsPerRow = Math.max(maxItemsPerRow, groups[idx].items.length);
+    }
+  }
+  const cardHeight =
+    cardHeaderHeight + cardPadding * 2 + maxItemsPerRow * itemHeight;
+  const rowGap = 20;
+  const height =
+    padding +
+    titleHeight +
+    rows * cardHeight +
+    (rows - 1) * rowGap +
+    60 +
+    padding;
+
+  canvas.width = width;
+  canvas.height = height;
+
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = "#333333";
+  ctx.font = "bold 30px sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText(titleText, width / 2, padding + 36);
+
+  ctx.fillStyle = "#6c757d";
+  ctx.font = "18px sans-serif";
+  ctx.fillText(resultLabel, width / 2, padding + 66);
+
+  const cardsStartY = padding + titleHeight;
+
+  groups.forEach((group, i) => {
+    const col = i % columns;
+    const row = Math.floor(i / columns);
+    const x = padding + col * (columnWidth + columnGap);
+    const y = cardsStartY + row * (cardHeight + rowGap);
+
+    ctx.fillStyle = "#ffffff";
+    ctx.strokeStyle = "#e0e0e0";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.roundRect(x, y, columnWidth, cardHeight, 12);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.fillStyle = group.color;
+    ctx.beginPath();
+    ctx.roundRect(x, y, columnWidth, cardHeaderHeight, [12, 12, 0, 0]);
+    ctx.fill();
+
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "bold 20px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText(group.label, x + columnWidth / 2, y + cardHeaderHeight / 2 + 6);
+
+    ctx.fillStyle = "#333333";
+    ctx.font = "16px sans-serif";
+    ctx.textAlign = "left";
+    group.items.forEach((item, j) => {
+      ctx.fillText(
+        item,
+        x + cardPadding,
+        y + cardHeaderHeight + cardPadding + j * itemHeight + 16
+      );
+    });
+  });
+
+  const now = new Date();
+  const dateString = now.toLocaleString(language);
+  ctx.fillStyle = "#6c757d";
+  ctx.font = "14px sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText(dateString, width / 2, height - padding + 10);
+
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else throw new Error("Failed to generate image blob");
+    }, "image/png");
+  });
+};
+
 export const copyImageToClipboard = async (blob: Blob): Promise<void> => {
   try {
     const clipboardItem = new ClipboardItem({ "image/png": blob });


### PR DESCRIPTION
## 概要

#4 のマージ後の仕上げ。レビューで判明した / 追加要望をまとめて対応。

## 主な変更

### ダークモード対応
- バトルモード配下のクラス（`.battle-controls`, `.battle-draw-count-*`, `.battle-progress`, `.battle-bar-*`, `.battle-empty`, `.battle-winner*`）について、`packages/web/src/styles/themes/dark.css` に対応する上書きを追加
- バトルモード UI がライト前提の白背景・黒文字のまま残っていた問題を修正

### モードを URL クエリで永続化
- `?mode=roulette` / `?mode=grouping` / `?mode=battle` で現在のモードを共有可能に
- 初期読込は `query > localStorage > roulette` の優先順
- モード切替時は URL も更新（`replaceState`）

### 結果画像のコピー・ダウンロード（バトル / グループ分け）
- バトル結果：勝者 + 票数ランキング棒グラフを PNG 化
- グループ分け結果：グループごとのメンバーカードを PNG 化
- どちらも 📋 コピーと 💾 ダウンロードに対応
- `generateBattleResultImage` / `generateGroupResultImage` を `imageUtils.ts` に追加
- 新規コンポーネント `BattleActions`, `GroupActions`（既存 `.action-button` / `.spinner` スタイル流用）

### リポジトリ規約の追加
- `CLAUDE.md` を新規追加し、「Web UI を追加・変更するときはダークモード対応も同時に行う」ルールを記載
- 同じ失念を繰り返さないための AI 向け + 人間向けガイドライン

## 確認済み

- `pnpm -r type-check` / `pnpm lint` / `pnpm -r test` いずれも通過
- ブラウザでの動作確認
  - `?mode=battle` で直接バトルモード起動
  - バトル・グループ分け双方で PNG ダウンロード成功
  - （ダークモードの視覚確認はレビューで画面を確認していただけると助かります）